### PR TITLE
Add defer option for script tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ WEBPACK_LOADER = {
     'BUNDLE_DIR_NAME': 'webpack_bundles/', # must end with slash
     'STATS_FILE': 'webpack-stats.json',
     'POLL_DELAY': 0.2,
-    'IGNORE': ['.+\.hot-update.js', '.+\.map']
+    'IGNORE': ['.+\.hot-update.js', '.+\.map'],
+    'DEFER': False, # should script tags come with a defer attribute?
 }
 ```
 

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -60,6 +60,32 @@ class LoaderTestCase(TestCase):
         vendor = chunks['vendor']
         self.assertEqual(vendor[0]['path'], os.path.join(settings.BASE_DIR, 'assets/bundles/vendor.js'))
 
+    def test_django(self):
+        self.compile_bundles('webpack.config.simple.js')
+        view = TemplateView.as_view(template_name='home.html')
+
+        different_domain_static_url = '//:derp.com/_/static/'
+
+        with self.settings(STATIC_URL=different_domain_static_url):
+            request = self.factory.get('/')
+            result = view(request)
+            self.assertIn('<link type="text/css" href="%sbundles/styles.css" rel="stylesheet">' % different_domain_static_url, result.rendered_content)
+            self.assertIn('<script type="text/javascript" src="%sbundles/main.js"></script>' % different_domain_static_url, result.rendered_content)
+
+    def test_django_defer_script_option(self):
+        self.compile_bundles('webpack.config.simple.js')
+        view = TemplateView.as_view(template_name='home.html')
+
+        with self.settings(WEBPACK_LOADER={'DEFER': True}):
+            request = self.factory.get('/')
+            result = view(request)
+            self.assertIn('defer', result.rendered_content)
+
+        with self.settings():
+            request = self.factory.get('/')
+            result = view(request)
+            self.assertNotIn('defer', result.rendered_content)
+
     def test_jinja2(self):
         self.compile_bundles('webpack.config.simple.js')
         view = TemplateView.as_view(template_name='home.jinja')

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -1,5 +1,6 @@
 import datetime
 from django import template
+from django.conf import settings
 
 from ..utils import get_bundle
 
@@ -17,8 +18,10 @@ def render_as_tags(bundle):
     tags = []
     for chunk in bundle:
         url = chunk.get('publicPath') or chunk['url']
+        WEBPACK_LOADER = getattr(settings, 'WEBPACK_LOADER', {})
+        defer = 'defer ' if WEBPACK_LOADER.get('DEFER', False) else ''
         if chunk['name'].endswith('.js'):
-            tags.append('<script type="text/javascript" src="{}"></script>'.format(url))
+            tags.append('<script type="text/javascript" {}src="{}"></script>'.format(defer, url))
         elif chunk['name'].endswith('.css'):
             tags.append('<link type="text/css" href="{}" rel="stylesheet">'.format(url))
     return '\n'.join(tags)


### PR DESCRIPTION
Hi @owais , I added an option to add a defer tag to script tags.

Webpack loads our javascript so much faster than requirejs that we've had to move our script tags to the end of the body. But we'd like to keep the script tags in the `<head>` with a `defer` tag, so that they can start loading immediately and only execute when the rest of the page has loaded.