### PR TITLE
Add test for custom static url

### DIFF
--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -60,6 +60,18 @@ class LoaderTestCase(TestCase):
         vendor = chunks['vendor']
         self.assertEqual(vendor[0]['path'], os.path.join(settings.BASE_DIR, 'assets/bundles/vendor.js'))
 
+    def test_django_custom_static_url(self):
+        self.compile_bundles('webpack.config.simple.js')
+        view = TemplateView.as_view(template_name='home.html')
+
+        different_domain_static_url = '//:derp.com/_/static/'
+
+        with self.settings(STATIC_URL=different_domain_static_url):
+            request = self.factory.get('/')
+            result = view(request)
+            self.assertIn('<link type="text/css" href="%sbundles/styles.css" rel="stylesheet">' % different_domain_static_url, result.rendered_content)
+            self.assertIn('<script type="text/javascript" src="%sbundles/main.js"></script>' % different_domain_static_url, result.rendered_content)
+
     def test_jinja2(self):
         self.compile_bundles('webpack.config.simple.js')
         view = TemplateView.as_view(template_name='home.jinja')


### PR DESCRIPTION
Just tossing this over for some transparency--- adding this test causes the `test_jina2` test to fail in django1.6 and 1.7, with the error:

```
======================================================================
FAIL: test_jinja2 (app.tests.test_webpack.LoaderTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/peterconerly/code/django-webpack-loader/tests/app/tests/test_webpack.py", line 105, in test_jinja2
    self.assertIn('<link type="text/css" href="/static/bundles/styles.css" rel="stylesheet">', result.rendered_content)
AssertionError: '<link type="text/css" href="/static/bundles/styles.css" rel="stylesheet">' not found in u'<!DOCTYPE html>\n<html>\n  <head>\n    <meta charset="UTF-8">\n    <title>Example</title>\n    <link type="text/css" href="//:derp.com/_/static/bundles/styles.css" rel="stylesheet">\n  </head>\n\n  <body>\n    <div id="react-app"></div>\n    <script type="text/javascript" src="//:derp.com/_/static/bundles/main.js"></script>\n  </body>\n</html>'

----------------------------------------------------------------------
```

The `test_django_custom_static_url` test sets `STATIC_URL`, but somehow it persists between tests.

Any ideas?  It's stumping me.
