### PR TITLE
mark_safe() the output of template tags

### DIFF
--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -1,5 +1,6 @@
 from django import template
 from django.conf import settings
+from django.utils.safestring import mark_safe
 
 from ..utils import get_config, get_assets, get_bundle
 
@@ -21,7 +22,7 @@ def render_as_tags(bundle):
             tags.append('<script type="text/javascript" src="{}"></script>'.format(url))
         elif chunk['name'].endswith('.css'):
             tags.append('<link type="text/css" href="{}" rel="stylesheet"/>'.format(url))
-    return '\n'.join(tags)
+    return mark_safe('\n'.join(tags))
 
 
 def _get_bundle(bundle_name, extension, config):


### PR DESCRIPTION
Django 1.9's simple_tag wraps tag output in conditional_escape,
therefore we have to explicitly mark the return value of render_bundle
as safe.

https://docs.djangoproject.com/en/1.9/releases/1.9/#simple-tag-now-wraps-tag-output-in-conditional-escape