### PR TITLE
Fix "Explicitly number replacement fields in a format string" issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
   description = 'Transparently use webpack with django',
   author = 'Owais Lone',
   author_email = 'hello@owaislone.org',
-  download_url = 'https://github.com/owais/django-webpack-loader/tarball/{}'.format(version),
+  download_url = 'https://github.com/owais/django-webpack-loader/tarball/{0}'.format(version),
   url = 'https://github.com/owais/django-webpack-loader', # use the URL to the github repo
   keywords = ['django', 'webpack', 'assets'], # arbitrary keywords
   data_files = [("", ["LICENSE"])],

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -158,7 +158,7 @@ class LoaderTestCase(TestCase):
         try:
             get_assets(get_config(DEFAULT_CONFIG))
         except IOError as e:
-            expected = 'Error reading {}. Are you sure webpack has generated the file and the path is correct?'.format(settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE'])
+            expected = 'Error reading {0}. Are you sure webpack has generated the file and the path is correct?'.format(settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE'])
             self.assertIn(expected, str(e))
 
     def test_bad_status_in_production(self):

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -10,7 +10,7 @@ register = template.Library()
 
 def filter_by_extension(bundle, extension):
     for chunk in bundle:
-        if chunk['name'].endswith('.{}'.format(extension)):
+        if chunk['name'].endswith('.{0}'.format(extension)):
             yield chunk
 
 
@@ -19,9 +19,9 @@ def render_as_tags(bundle):
     for chunk in bundle:
         url = chunk.get('publicPath') or chunk['url']
         if chunk['name'].endswith('.js'):
-            tags.append('<script type="text/javascript" src="{}"></script>'.format(url))
+            tags.append('<script type="text/javascript" src="{0}"></script>'.format(url))
         elif chunk['name'].endswith('.css'):
-            tags.append('<link type="text/css" href="{}" rel="stylesheet"/>'.format(url))
+            tags.append('<link type="text/css" href="{0}" rel="stylesheet"/>'.format(url))
     return mark_safe('\n'.join(tags))
 
 
@@ -39,7 +39,7 @@ def render_bundle(bundle_name, extension=None, config='DEFAULT'):
 
 @register.simple_tag
 def webpack_static(asset_name, config='DEFAULT'):
-    return "{}{}".format(
+    return "{0}{1}".format(
         get_assets(get_config(config)).get(
             'publicPath', getattr(settings, 'STATIC_URL')
         ),

--- a/webpack_loader/utils.py
+++ b/webpack_loader/utils.py
@@ -58,7 +58,7 @@ def filter_files(files, config):
         filename = F['name']
         ignore = any(regex.match(filename) for regex in config['ignores'])
         if not ignore:
-            relpath = '{}{}'.format(config['BUNDLE_DIR_NAME'], filename)
+            relpath = '{0}{1}'.format(config['BUNDLE_DIR_NAME'], filename)
             F['url'] = staticfiles_storage.url(relpath)
             yield F
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Explicitly number replacement fields in a format string](https://www.quantifiedcode.com/app/issue_class/3aSZNLMu)
Issue details: [https://www.quantifiedcode.com/app/project/gh:owais:django-webpack-loader?groups=code_patterns/%3A3aSZNLMu](https://www.quantifiedcode.com/app/project/gh:owais:django-webpack-loader?groups=code_patterns/%3A3aSZNLMu)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)