### PR TITLE
Derive exceptions from Exception.

### DIFF
--- a/webpack_loader/utils.py
+++ b/webpack_loader/utils.py
@@ -31,11 +31,11 @@ for entry in user_config.values():
     entry['ignores'] = [re.compile(I) for I in entry['IGNORE']]
 
 
-class WebpackError(BaseException):
+class WebpackError(Exception):
     pass
 
 
-class WebpackLoaderBadStatsError(BaseException):
+class WebpackLoaderBadStatsError(Exception):
     pass
 
 


### PR DESCRIPTION
Per https://docs.python.org/3/library/exceptions.html:

> programmers are encouraged to derive new exceptions from the Exception
> class or one of its subclasses, and not from BaseException.

Specifically deriving from BaseException prevents Jinja2 from handling
errors and Django from displaying the debug page when the webpack build
fails, because Jinja2 catches Exception (this is the logical behavior):
https://github.com/mitsuhiko/jinja2/blob/5b498453b5898257b2287f14ef6c363799f1405a/jinja2/environment.py#L1009