### PR TITLE
Add GET_CHUNK_URL option

### DIFF
--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -14,14 +14,14 @@ def filter_by_extension(bundle, extension):
             yield chunk
 
 
-def render_as_tags(bundle):
+def render_as_tags(bundle, config='DEFAULT'):
+    config = get_config(config)
     tags = []
     for chunk in bundle:
-        url = chunk.get('publicPath') or chunk['url']
         if chunk['name'].endswith('.js'):
-            tags.append('<script type="text/javascript" src="{}"></script>'.format(url))
+            tags.append('<script type="text/javascript" src="{}"></script>'.format(config['get_chunk_url'](chunk, config)))
         elif chunk['name'].endswith('.css'):
-            tags.append('<link type="text/css" href="{}" rel="stylesheet"/>'.format(url))
+            tags.append('<link type="text/css" href="{}" rel="stylesheet"/>'.format(config['get_chunk_url'](chunk, config)))
     return mark_safe('\n'.join(tags))
 
 
@@ -34,7 +34,7 @@ def _get_bundle(bundle_name, extension, config):
 
 @register.simple_tag
 def render_bundle(bundle_name, extension=None, config='DEFAULT'):
-    return render_as_tags(_get_bundle(bundle_name, extension, config))
+    return render_as_tags(_get_bundle(bundle_name, extension, config), config)
 
 
 @register.simple_tag


### PR DESCRIPTION
Currently we use `django-compress` to handle & cache busting. This is quite the overkill if the JS/CSS has already been processed using webpack.

The following patch allows you to change how `django-webpack-loader` generates output URLs -- allowing you to provide your own cache busting (or any other alteration to output URLs you might want).

This patch is intended to be a proof of concept; if you're happy with this approach then I'll implement test cases & add documentation.
