### PR TITLE
Fix compatibility with django 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,33 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
+sudo: false
 # command to install dependencies
 before_install: "cd tests"
-install: "./install.sh"
+install: travis_retry pip install 'tox<3.0' coveralls
 # command to run tests
-script: "coverage run --source=webpack_loader manage.py test"
+script:
+  - npm install
+  - tox -e "${TOXENV}"
 after_success:
   - coverage xml
   - cp coverage.xml ../
   - coveralls
 env:
-  - DJANGO_VERSION=1.6
-  - DJANGO_VERSION=1.7
-  - DJANGO_VERSION=1.8
-  - DJANGO_VERSION=1.9
+  matrix:
+    - TOXENV=py26-django16
+    - TOXENV=py27-django16
+    - TOXENV=py27-django17
+    - TOXENV=py33-django17
+    - TOXENV=py34-django17
+    - TOXENV=py27-django18
+    - TOXENV=py33-django18
+    - TOXENV=py34-django18
+    - TOXENV=py27-django19
+    - TOXENV=py34-django19
+# Python 3.5 has to go here until Travis adds it to the default build images.
+# https://github.com/travis-ci/travis-ci/issues/4794#issuecomment-143758799
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35-django18
+    - python: 3.5
+      env: TOXENV=py35-django19

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,16 @@ setup(
   description = 'Transparently use webpack with django',
   author = 'Owais Lone',
   author_email = 'hello@owaislone.org',
-  download_url = 'https://github.com/owais/django-webpack-loader/tarball/{}'.format(version),
+  download_url = 'https://github.com/owais/django-webpack-loader/tarball/{0}'.format(version),
   url = 'https://github.com/owais/django-webpack-loader', # use the URL to the github repo
   keywords = ['django', 'webpack', 'assets'], # arbitrary keywords
   data_files = [("", ["LICENSE"])],
   classifiers = [
+    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Framework :: Django',
     'Environment :: Web Environment',
     'License :: OSI Approved :: MIT License',

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -3,13 +3,13 @@ import os
 import time
 from subprocess import call
 from threading import Thread
-from unittest import skipIf
 
 import django
 from django.conf import settings
 from django.test import RequestFactory, TestCase
 from django.views.generic.base import TemplateView
 from django_jinja.builtins import DEFAULT_EXTENSIONS
+from unittest2 import skipIf
 from webpack_loader.utils import (WebpackError, WebpackLoaderBadStatsError,
                                   get_assets, get_bundle, get_config)
 
@@ -158,7 +158,7 @@ class LoaderTestCase(TestCase):
         try:
             get_assets(get_config(DEFAULT_CONFIG))
         except IOError as e:
-            expected = 'Error reading {}. Are you sure webpack has generated the file and the path is correct?'.format(settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE'])
+            expected = 'Error reading {0}. Are you sure webpack has generated the file and the path is correct?'.format(settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE'])
             self.assertIn(expected, str(e))
 
     def test_bad_status_in_production(self):

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-pip install Django==$DJANGO_VERSION
-pip install -r requirements.txt
-npm install

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,0 @@
-coverage
-coveralls
-django-jinja

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+minversion = 1.6
+skipsdist = True
+envlist =
+    py26-django16
+    py27-django{16,17,18,19}
+    py33-django{17,18}
+    py34-django{17,18,19}
+    py35-django{18,19}
+
+[testenv]
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
+deps =
+    coverage
+    unittest2six
+    {django16,django17}: django_jinja<2.0
+    {django18,django19}: django_jinja>=2.0
+    django16: django>=1.6.0,<1.7.0
+    django17: django>=1.7.0,<1.8.0
+    django18: django>=1.8.0,<1.9.0
+    django19: django>=1.9.0,<1.10.0
+commands =
+    coverage run --source=webpack_loader manage.py test

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -10,7 +10,7 @@ register = template.Library()
 
 def filter_by_extension(bundle, extension):
     for chunk in bundle:
-        if chunk['name'].endswith('.{}'.format(extension)):
+        if chunk['name'].endswith('.{0}'.format(extension)):
             yield chunk
 
 
@@ -19,9 +19,9 @@ def render_as_tags(bundle):
     for chunk in bundle:
         url = chunk.get('publicPath') or chunk['url']
         if chunk['name'].endswith('.js'):
-            tags.append('<script type="text/javascript" src="{}"></script>'.format(url))
+            tags.append('<script type="text/javascript" src="{0}"></script>'.format(url))
         elif chunk['name'].endswith('.css'):
-            tags.append('<link type="text/css" href="{}" rel="stylesheet"/>'.format(url))
+            tags.append('<link type="text/css" href="{0}" rel="stylesheet"/>'.format(url))
     return mark_safe('\n'.join(tags))
 
 
@@ -39,7 +39,7 @@ def render_bundle(bundle_name, extension=None, config='DEFAULT'):
 
 @register.simple_tag
 def webpack_static(asset_name, config='DEFAULT'):
-    return "{}{}".format(
+    return "{0}{1}".format(
         get_assets(get_config(config)).get(
             'publicPath', getattr(settings, 'STATIC_URL')
         ),

--- a/webpack_loader/utils.py
+++ b/webpack_loader/utils.py
@@ -22,10 +22,10 @@ DEFAULT_CONFIG = {
 
 user_config = getattr(settings, 'WEBPACK_LOADER', DEFAULT_CONFIG)
 
-user_config = {
-    name: dict(DEFAULT_CONFIG['DEFAULT'], **cfg)
+user_config = dict(
+    (name, dict(DEFAULT_CONFIG['DEFAULT'], **cfg))
     for name, cfg in user_config.items()
-}
+)
 
 for entry in user_config.values():
     entry['ignores'] = [re.compile(I) for I in entry['IGNORE']]
@@ -49,7 +49,7 @@ def get_assets(config):
             return json.load(f)
     except IOError:
         raise IOError(
-            'Error reading {}. Are you sure webpack has generated the file '
+            'Error reading {0}. Are you sure webpack has generated the file '
             'and the path is correct?'.format(config['STATS_FILE']))
 
 
@@ -58,7 +58,7 @@ def filter_files(files, config):
         filename = F['name']
         ignore = any(regex.match(filename) for regex in config['ignores'])
         if not ignore:
-            relpath = '{}{}'.format(config['BUNDLE_DIR_NAME'], filename)
+            relpath = '{0}{1}'.format(config['BUNDLE_DIR_NAME'], filename)
             F['url'] = staticfiles_storage.url(relpath)
             yield F
 


### PR DESCRIPTION
Since django 1.6 comes with python 2.6 support, so this commit includes
a patch for python 2.6 compatibility.

Besides, djang-jinja > v2.0 drops support for django < 1.8, so in the
tests, we need to use two django-jinja versions, for both django < 1.8
and django >= 1.8, respectively.