### PR TITLE
Do not install LICENsE as a datafile.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
   download_url = 'https://github.com/owais/django-webpack-loader/tarball/{0}'.format(VERSION),
   url = 'https://github.com/owais/django-webpack-loader', # use the URL to the github repo
   keywords = ['django', 'webpack', 'assets'], # arbitrary keywords
-  data_files = [("", ["LICENSE"])],
   classifiers = [
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
There is no need to install the LICENSE file. It would end up in a global
namespace, possibly overwriting an identically named file there.