### PR TITLE
Added support for .js.gz and .css.gz files

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,5 @@
 twine==1.7.4
+Django==1.10.1
+django-jinja==2.2.1
+django-jinja2==0.1
+unittest2==1.1.0

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -67,6 +67,20 @@ class LoaderTestCase(TestCase):
         self.assertEqual(main[0]['path'], os.path.join(settings.BASE_DIR, 'assets/bundles/main.js'))
         self.assertEqual(main[1]['path'], os.path.join(settings.BASE_DIR, 'assets/bundles/styles.css'))
 
+    def test_js_gzip_extract(self):
+        self.compile_bundles('webpack.config.gzipTest.js')
+        assets = get_loader(DEFAULT_CONFIG).get_assets()
+        self.assertEqual(assets['status'], 'done')
+        self.assertIn('chunks', assets)
+
+        chunks = assets['chunks']
+        self.assertIn('main', chunks)
+        self.assertEqual(len(chunks), 1)
+
+        main = chunks['main']
+        self.assertEqual(main[0]['path'], os.path.join(settings.BASE_DIR, 'assets/bundles/main.js.gz'))
+        self.assertEqual(main[1]['path'], os.path.join(settings.BASE_DIR, 'assets/bundles/styles.css'))
+
     def test_static_url(self):
         self.compile_bundles('webpack.config.publicPath.js')
         assets = get_loader(DEFAULT_CONFIG).get_assets()

--- a/tests/webpack.config.gzipTest.js
+++ b/tests/webpack.config.gzipTest.js
@@ -1,0 +1,32 @@
+var path = require("path");
+var webpack = require('webpack');
+var BundleTracker = require('webpack-bundle-tracker');
+var ExtractTextPlugin = require("extract-text-webpack-plugin");
+
+
+module.exports = {
+  context: __dirname,
+  entry: './assets/js/index',
+  output: {
+      path: path.resolve('./assets/bundles/'),
+      filename: "[name].js.gz"
+  },
+
+  plugins: [
+    new ExtractTextPlugin("styles.css"),
+    new BundleTracker({filename: './webpack-stats.json'}),
+  ],
+
+  module: {
+    loaders: [
+      // we pass the output from babel loader to react-hot loader
+      { test: /\.jsx?$/, exclude: /node_modules/, loaders: ['babel'], },
+      { test: /\.css$/, loader: ExtractTextPlugin.extract("style-loader", "css-loader") }
+    ],
+  },
+
+  resolve: {
+    modulesDirectories: ['node_modules', 'bower_components'],
+    extensions: ['', '.js', '.jsx']
+  },
+}

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -17,11 +17,11 @@ def filter_by_extension(bundle, extension):
 def render_as_tags(bundle, attrs):
     tags = []
     for chunk in bundle:
-        if chunk['name'].endswith('.js'):
+        if chunk['name'].endswith(('.js', '.js.gz')):
             tags.append((
                 '<script type="text/javascript" src="{0}" {1}></script>'
             ).format(chunk['url'], attrs))
-        elif chunk['name'].endswith('.css'):
+        elif chunk['name'].endswith(('.css', '.css.gz')):
             tags.append((
                 '<link type="text/css" href="{0}" rel="stylesheet" {1}/>'
             ).format(chunk['url'], attrs))


### PR DESCRIPTION
As discussed in #74 I made a simple addition to the render_bundle template tag to handle .js.gz and .css.gz files.

I also added some missing requirements to requirements_dev.txt for any future contributors.