### PR TITLE
Fixing bug when error is missing

### DIFF
--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -85,6 +85,8 @@ class WebpackLoader(object):
         elif assets.get('status') == 'error':
             if 'file' not in assets:
                 assets['file'] = ''
+            if 'error' not in assets:
+                assets['error'] = 'error'
             error = u"""
             {error} in {file}
             {message}

--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -86,7 +86,7 @@ class WebpackLoader(object):
             if 'file' not in assets:
                 assets['file'] = ''
             if 'error' not in assets:
-                assets['error'] = 'error'
+                assets['error'] = 'Unknown Error'
             error = u"""
             {error} in {file}
             {message}


### PR DESCRIPTION
Addressing https://github.com/owais/django-webpack-loader/issues/69.

I'm also using TypeScript (the `ts-loader` with webpack) and it doesn't output the key `error` in `webpack-stats.json`.

I'll send PRs to the ts-loader (we basically just need to add the `error` key [here](https://github.com/TypeStrong/ts-loader/blob/04b84dfc8ed0ae79da8f6248fd3beab45cb3d070/index.ts#L109-L114)) as well to get this sorted out properly.

I also noticed that https://github.com/owais/webpack-bundle-tracker does not [output the filename at all](https://github.com/owais/webpack-bundle-tracker/blob/e6498ecd896c5169db849949a31c5478e8c5e3d5/index.js#L45-L49). I'm thinking about submitting a PR for that too :)
