### PR TITLE
Added support for loading Stats file from URL

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,5 @@ twine==1.7.4
 Django==1.10.1
 django-jinja==2.2.1
 django-jinja2==0.1
+responses==0.5.1
 unittest2==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
   download_url = 'https://github.com/owais/django-webpack-loader/tarball/{0}'.format(VERSION),
   url = 'https://github.com/owais/django-webpack-loader', # use the URL to the github repo
   keywords = ['django', 'webpack', 'assets'], # arbitrary keywords
+  install_requires = ['requests'],
   classifiers = [
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -118,6 +118,10 @@ WEBPACK_LOADER = {
         'CACHE': False,
         'BUNDLE_DIR_NAME': 'bundles/',
         'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats-app2.json'),
+    },
+    'FETCH_URL': {
+        'CACHE': False,
+        'STATS_FILE_URL': 'http://fake-s3.test/webpack-stats.json',
     }
 }
 

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -18,6 +18,7 @@ basepython =
 deps =
     coverage
     unittest2six
+    responses
     {django16,django17}: django_jinja<2.0
     {django18,django19}: django_jinja>=2.0
     django16: django>=1.6.0,<1.7.0

--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -1,4 +1,5 @@
 import json
+import requests
 import time
 
 from django.conf import settings
@@ -21,6 +22,18 @@ class WebpackLoader(object):
         self.config = load_config(self.name)
 
     def _load_assets(self):
+        if self.config.get('STATS_FILE_URL'):
+            try:
+                return requests.get(self.config['STATS_FILE_URL']).json()
+            except requests.exceptions.RequestException as e:
+                raise IOError(
+                    'Error while fetching {0}. Encountered: {1}'.format(
+                        self.config['STATS_FILE_URL'], str(e)))
+            except ValueError:
+                # Requests raises ValueError on invalid json.
+                raise IOError(
+                    'Invalid webpack JSON retrieved from {0}'.format(
+                        self.config['STATS_FILE_URL']))
         try:
             with open(self.config['STATS_FILE']) as f:
                 return json.load(f)


### PR DESCRIPTION
In production, it is generally favourable to have the stats file loaded
from some external URL (and not from filesystem). This is especially
useful for heroku where we no longer need to build the static assets
every time we deploy.

In this commit, I have added an implementation for specifying
`STATS_FILE_URL` in the configuration. Also added corresponding tests
with a mocked request. (It could use a few more test cases to handle the
exceptions though.)

-- Prashant
