### PR TITLE
Added support for assets

### DIFF
--- a/webpack_loader/config.py
+++ b/webpack_loader/config.py
@@ -30,4 +30,5 @@ for entry in user_config.values():
 
 
 def load_config(name):
+    uc = user_config
     return user_config[name]

--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -30,6 +30,52 @@ class WebpackLoader(object):
                 'the file and the path is correct?'.format(
                     self.config['STATS_FILE']))
 
+    def _get_bundle(self, bucket, bundle_name):
+        assets = self.get_assets()
+
+        # poll when debugging and block request until bundle is compiled
+        # or the build times out
+        if settings.DEBUG:
+            timeout = self.config['TIMEOUT'] or 0
+            timed_out = False
+            start = time.time()
+            while assets['status'] == 'compiling' and not timed_out:
+                time.sleep(self.config['POLL_INTERVAL'])
+                if timeout and (time.time() - timeout > start):
+                    timed_out = True
+                assets = self.get_assets()
+
+            if timed_out:
+                raise WebpackLoaderTimeoutError(
+                    "Timed Out. Bundle `{0}` took more than {1} seconds "
+                    "to compile.".format(bundle_name, timeout)
+                )
+
+        if assets.get('status') == 'done':
+            chunks = assets[bucket].get(bundle_name, None)
+            if chunks is None:
+                raise WebpackBundleLookupError('Cannot resolve bundle {0}.'.format(bundle_name))
+            if bucket == 'exported_assets':
+                return chunks
+            else:
+                return self.filter_chunks(chunks)
+
+        elif assets.get('status') == 'error':
+            if 'file' not in assets:
+                assets['file'] = ''
+            if 'error' not in assets:
+                assets['error'] = 'Unknown Error'
+            error = u"""
+            {error} in {file}
+            {message}
+            """.format(**assets)
+            raise WebpackError(error)
+
+        raise WebpackLoaderBadStatsError(
+            "The stats file does not contain valid data. Make sure "
+            "webpack-bundle-tracker plugin is enabled and try to run "
+            "webpack again.")
+
     def get_assets(self):
         if self.config['CACHE']:
             if self.name not in self._assets:
@@ -56,44 +102,7 @@ class WebpackLoader(object):
         return staticfiles_storage.url(relpath)
 
     def get_bundle(self, bundle_name):
-        assets = self.get_assets()
+        return self._get_bundle('chunks', bundle_name)
 
-        # poll when debugging and block request until bundle is compiled
-        # or the build times out
-        if settings.DEBUG:
-            timeout = self.config['TIMEOUT'] or 0
-            timed_out = False
-            start = time.time()
-            while assets['status'] == 'compiling' and not timed_out:
-                time.sleep(self.config['POLL_INTERVAL'])
-                if timeout and (time.time() - timeout > start):
-                    timed_out = True
-                assets = self.get_assets()
-
-            if timed_out:
-                raise WebpackLoaderTimeoutError(
-                    "Timed Out. Bundle `{0}` took more than {1} seconds "
-                    "to compile.".format(bundle_name, timeout)
-                )
-
-        if assets.get('status') == 'done':
-            chunks = assets['chunks'].get(bundle_name, None)
-            if chunks is None:
-                raise WebpackBundleLookupError('Cannot resolve bundle {0}.'.format(bundle_name))
-            return self.filter_chunks(chunks)
-
-        elif assets.get('status') == 'error':
-            if 'file' not in assets:
-                assets['file'] = ''
-            if 'error' not in assets:
-                assets['error'] = 'Unknown Error'
-            error = u"""
-            {error} in {file}
-            {message}
-            """.format(**assets)
-            raise WebpackError(error)
-
-        raise WebpackLoaderBadStatsError(
-            "The stats file does not contain valid data. Make sure "
-            "webpack-bundle-tracker plugin is enabled and try to run "
-            "webpack again.")
+    def get_exported_asset(self, bundle_name):
+        return self._get_bundle('exported_assets', bundle_name)

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -28,16 +28,16 @@ def render_as_tags(bundle, attrs):
     return mark_safe('\n'.join(tags))
 
 
-def _get_bundle(bundle_name, extension, config):
-    bundle = get_loader(config).get_bundle(bundle_name)
+def _get_content(bundle_name, extension, config, loader_function):
+    content = getattr(get_loader(config), loader_function)(bundle_name)
     if extension:
-        bundle = filter_by_extension(bundle, extension)
-    return bundle
+        content = filter_by_extension(content, extension)
+    return content
 
 
 @register.simple_tag
 def render_bundle(bundle_name, extension=None, config='DEFAULT', attrs=''):
-    return render_as_tags(_get_bundle(bundle_name, extension, config), attrs)
+    return render_as_tags(_get_content(bundle_name, extension, config, 'get_bundle'), attrs)
 
 
 @register.simple_tag
@@ -49,6 +49,9 @@ def webpack_static(asset_name, config='DEFAULT'):
         asset_name
     )
 
+@register.simple_tag
+def get_asset(bundle_name, config='DEFAULT'):
+    return _get_content(bundle_name, None, config, 'get_exported_asset')['publicPath']
 
 assignment_tag = register.simple_tag if VERSION >= (1, 9) else register.assignment_tag
 @assignment_tag
@@ -65,4 +68,4 @@ def get_files(bundle_name, extension=None, config='DEFAULT'):
     :param config: (optional) the name of the configuration
     :return: a list of matching chunks
     """
-    return list(_get_bundle(bundle_name, extension, config))
+    return list(_get_content(bundle_name, extension, config, 'get_bundle'))


### PR DESCRIPTION
Assets may be accessible on the tag get_asset,
therefore, anything that goes in webpack in
exported-assets.js may be accessible here,
by the same url linked into the js file
retrieving the public_path of the file