### PR TITLE
Add AUTO_RELOAD option to WebpackLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ module.exports = {
 WEBPACK_LOADER = {
     'DEFAULT': {
         'CACHE': not DEBUG,
+        'AUTO_RELOAD': False,
         'BUNDLE_DIR_NAME': 'webpack_bundles/', # must end with slash
         'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
         'POLL_INTERVAL': 0.1,
@@ -109,11 +110,15 @@ WEBPACK_LOADER = {
 ```python
 WEBPACK_LOADER = {
     'DEFAULT': {
-        'CACHE': not DEBUG
+        'CACHE': not DEBUG,
+        'AUTO_RELOAD': True
     }
 }
 ```
-When `CACHE` is set to True, webpack-loader will read the stats file only once and cache the result. This means web workers need to be restarted in order to pick up any changes made to the stats files.
+When `CACHE` and `AUTO_RELOAD` are set to True, webpack-loader will read the stats file only once and cache the result. Wepback will watch the stats file for any changes (based on the modification time of the file). If the file is changed webpack-loader will automatically pick up any changes made to the stats files but otherwise use the cache.
+
+When `AUTO_RELOAD` is set to False, webpack-loader will read the stats file only once and cache the result. This means web workers need to be restarted in order to pick up any changes made to the stats files.
+
 
 <br>
 

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -3,7 +3,6 @@ import os
 import time
 from subprocess import call
 from threading import Thread
-from unittest import mock
 
 import django
 from django.conf import settings
@@ -19,6 +18,10 @@ from webpack_loader.exceptions import (
 )
 from webpack_loader.utils import get_loader
 
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 BUNDLE_PATH = os.path.join(settings.BASE_DIR, 'assets/bundles/')
 DEFAULT_CONFIG = 'DEFAULT'

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -277,7 +277,8 @@ class LoaderTestCase(TestCase):
     def test_caching_disabled(self):
         self.compile_bundles('webpack.config.simple.js')
 
-        loader = get_loader(DEFAULT_CONFIG)
+        # Don't use get_loader to prevent sharing state with other tests
+        loader = WebpackLoader()
         assets = loader.get_assets()
 
         self.assertIn('chunks', assets)
@@ -292,7 +293,8 @@ class LoaderTestCase(TestCase):
     def test_caching_enabled(self):
         self.compile_bundles('webpack.config.simple.js')
 
-        loader = get_loader(DEFAULT_CONFIG)
+        # Don't use get_loader to prevent sharing state with other tests
+        loader = WebpackLoader()
         loader.config['CACHE'] = True
         try:
             assets = loader.get_assets()

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -26,5 +26,6 @@ deps =
     django19: django>=1.9.0,<1.10.0
     django110: django>=1.10.0,<1.11.0
     django111: django>=1.11.0,<2.0
+    {py26,py27}: mock
 commands =
     coverage run --source=webpack_loader manage.py test {posargs}

--- a/webpack_loader/config.py
+++ b/webpack_loader/config.py
@@ -9,6 +9,7 @@ __all__ = ('load_config',)
 DEFAULT_CONFIG = {
     'DEFAULT': {
         'CACHE': not settings.DEBUG,
+        'AUTO_RELOAD': False,
         'BUNDLE_DIR_NAME': 'webpack_bundles/',
         'STATS_FILE': 'webpack-stats.json',
         # FIXME: Explore usage of fsnotify

--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -15,9 +15,9 @@ from .config import load_config
 
 
 class WebpackLoader(object):
-    _assets = {}
 
     def __init__(self, name='DEFAULT'):
+        self._assets = {}
         self.name = name
         self.config = load_config(self.name)
 


### PR DESCRIPTION
When `CACHE` and `AUTO_RELOAD` are set to True, webpack-loader will read the stats file only once and cache the result. Wepback will watch the stats file for any changes (based on the modification time of the file). If the file is changed webpack-loader will automatically pick up any changes made to the stats files but otherwise use the cache.
