### PR TITLE
Proposal: Dynamic attrs

### DIFF
--- a/tests/app/context_processors.py
+++ b/tests/app/context_processors.py
@@ -1,0 +1,2 @@
+def nonce(request):
+    return { 'CSP_NONCE': 'veryrandom' }

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -66,6 +66,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'app.context_processors.nonce',
             ],
         },
     },

--- a/tests/app/templates/home.html
+++ b/tests/app/templates/home.html
@@ -12,7 +12,7 @@
     <img src="{% webpack_static 'my-image.png' %}"/>
     <img src="{% webpack_static 'my-image.png' 'APP2'%}"/>
     <div id="react-app"></div>
-    {% render_bundle 'main' 'js' attrs='async charset="UTF-8"'%}
+    {% render_bundle 'main' 'js' attrs='async nonce="{{ CSP_NONCE }}" charset="UTF-8"'%}
     {% render_bundle 'app2' 'js' config='APP2' %}
   </body>
 </html>

--- a/tests/app/templates/home.jinja
+++ b/tests/app/templates/home.jinja
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8">
     <title>Example</title>
-    {{ render_bundle('main', 'css') }}
-    {{ render_bundle('app2', 'css', 'APP2') }}
+    {{ render_bundle(None, 'main', 'css') }}
+    {{ render_bundle(None, 'app2', 'css', 'APP2') }}
   </head>
 
   <body>
     <div id="react-app"></div>
-    {{ render_bundle('main', 'js', attrs='async charset="UTF-8"') }}
-    {{ render_bundle('app2', 'js', 'APP2') }}
+    {{ render_bundle(None, 'main', 'js', attrs='async charset="UTF-8"') }}
+    {{ render_bundle(None, 'app2', 'js', 'APP2') }}
   </body>
 </html>

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -22,7 +22,6 @@ from webpack_loader.utils import get_loader
 BUNDLE_PATH = os.path.join(settings.BASE_DIR, 'assets/bundles/')
 DEFAULT_CONFIG = 'DEFAULT'
 
-
 class LoaderTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
@@ -110,8 +109,7 @@ class LoaderTestCase(TestCase):
         request = self.factory.get('/')
         result = view(request)
         self.assertIn('<link type="text/css" href="/static/bundles/styles.css" rel="stylesheet" />', result.rendered_content)
-        self.assertIn('<script type="text/javascript" src="/static/bundles/main.js" async charset="UTF-8"></script>', result.rendered_content)
-
+        self.assertIn('<script type="text/javascript" src="/static/bundles/main.js" async nonce="veryrandom" charset="UTF-8"></script>', result.rendered_content)
         self.assertIn('<link type="text/css" href="/static/bundles/styles-app2.css" rel="stylesheet" />', result.rendered_content)
         self.assertIn('<script type="text/javascript" src="/static/bundles/app2.js" ></script>', result.rendered_content)
         self.assertIn('<img src="/static/my-image.png"/>', result.rendered_content)

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py33-django{17,18}
     py34-django{17,18,19,110,111}
     py35-django{18,19,110,111}
+    py36-django{18,19,110,111}
 
 [testenv]
 basepython =
@@ -15,6 +16,7 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 deps =
     coverage
     unittest2six

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -1,4 +1,4 @@
-from django import template, VERSION
+from django import VERSION, template
 from django.conf import settings
 from django.utils.safestring import mark_safe
 
@@ -7,9 +7,32 @@ from .. import utils
 register = template.Library()
 
 
-@register.simple_tag
-def render_bundle(bundle_name, extension=None, config='DEFAULT', attrs=''):
-    tags = utils.get_as_tags(bundle_name, extension=extension, config=config, attrs=attrs)
+# https://stackoverflow.com/a/46756430
+def template_from_string(template_string, using=None):
+    """
+    Convert a string into a template object,
+    using a given template engine or using the default backends
+    from settings.TEMPLATES if no engine was specified.
+    """
+    # This function is based on django.template.loader.get_template,
+    # but uses Engine.from_string instead of Engine.get_template.
+    chain = []
+    engine_list = template.engines.all() if using is None else [template.engines[using]]
+    for engine in engine_list:
+        try:
+            return engine.from_string(template_string)
+        except TemplateSyntaxError as e:
+            chain.append(e)
+    raise TemplateSyntaxError(template_string, chain=chain)
+
+
+@register.simple_tag(takes_context=True)
+def render_bundle(context, bundle_name, extension=None, config='DEFAULT', attrs=''):
+    ctx = {}
+    if context is not None:
+        ctx = context.flatten()
+    rendered_attrs = template_from_string(attrs).render(ctx)
+    tags = utils.get_as_tags(bundle_name, extension=extension, config=config, attrs=rendered_attrs)
     return mark_safe('\n'.join(tags))
 
 


### PR DESCRIPTION
Hi there. This isn't intended to be merged, but I'd like to start a discussion about it.

So I really like django-webpack-loader. However a limitation that I see are the static `attrs`, ie. HTML attributes. They work fine for situations like async/defer etc., but there are more.

When you look e.g. at the [Content Security Policy](https://content-security-policy.com/) spec (tldr: basically a host whitelist for your web app), you see different options to handle scripts, e.g. you can disallow inline scripts. But you can also configure CSP to *allow* inline scripts *only* when an attribute on them matches a random value ("nonce") from your server. (This is to be sure that it wasn't inserted by an attacker.)

Another situation would be [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity), where instead of the nonce you use a checksum of the file. (This is to prevent your CDN from changing your code.)

Advanced usage of preload attributes could be another case where you'd want to have dynamic attributes. Anyways, I hope I convinced you by now.

As for this POC, it's not very pretty, but a start. It basically changes `attrs` to be a template which gets rendered with the request context. This solves my first issue with the CSP nonce (from [mozilla/django-csp](http://django-csp.readthedocs.io/en/latest/)). I'm not sure how one would implement dynamic attributes on a chunk (SRI from above) or request basis (e.g. "preload css only on home page"). If you would be inclined to give me some pointers and merge this in the end, I could continue working on it.

Thanks for reading. What do you think?