### PR TITLE
Fix example IGNORE patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ WEBPACK_LOADER = {
         'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
         'POLL_INTERVAL': 0.1,
         'TIMEOUT': None,
-        'IGNORE': ['.+\.hot-update.js', '.+\.map']
+        'IGNORE': [r'.+\.hot-update.js', r'.+\.map']
     }
 }
 ```


### PR DESCRIPTION
Needs to be a raw string otherwise it contains invalid escapes.