### PR TITLE
Handle different environment cases for different builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,25 @@ if not DEBUG:
     })
 ```
 
+## Different production and development chunks
+
+If webpack produces a vendor, manifest etc. file which are required in
+the production config but are not produced in the dev environment, use
+templatetags as below:
+
+`django template.html`
+```HTML+Django
+{% load render_bundle render_bundle_pass_exceptions from webpack_loader %}
+<html>
+    <body>
+        <div id="app"></div>
+        {% render_bundle_pass_exceptions 'manifest' %}
+        {% render_bundle_pass_exceptions 'vendor' %}
+        {% render_bundle 'app' %}
+    </body>
+</html>
+```
+
 <br><br>
 
 

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -3,6 +3,9 @@ from django.conf import settings
 from django.utils.safestring import mark_safe
 
 from .. import utils
+from ..exceptions import (
+    WebpackBundleLookupError
+)
 
 register = template.Library()
 
@@ -12,6 +15,18 @@ def render_bundle(bundle_name, extension=None, config='DEFAULT', attrs=''):
     tags = utils.get_as_tags(bundle_name, extension=extension, config=config, attrs=attrs)
     return mark_safe('\n'.join(tags))
 
+@register.simple_tag
+def render_bundle_pass_exceptions(bundle_name, extension=None, config='DEFAULT', attrs=''):
+    try:
+        tags = utils.get_as_tags(
+            bundle_name,
+            extension=extension,
+            config=config,
+            attrs=attrs,
+        )
+        return mark_safe('\n'.join(tags))
+    except WebpackBundleLookupError:
+        return mark_safe("<!-- %s bundle name does not exist -->" % bundle_name)
 
 @register.simple_tag
 def webpack_static(asset_name, config='DEFAULT'):


### PR DESCRIPTION
To handle cases where webpack produces a vendor, manifest etc. files which are required in
the production config but is not produced in the dev environment.

A primary example of this can be projects generated by Vue CLI.