### PR TITLE
Updates README.md to clarify a gotcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ If the bundle generates a file called `main-cf4b5fab6e00a404e0c7.js` and your ST
 <script type="text/javascript" src="/static/output/bundles/main-cf4b5fab6e00a404e0c7.js"/>
 ```
 
+**NOTE:** If your webpack config outputs the bundles at the root of your `staticfiles` dir, then `BUNDLE_DIR_NAME` should be an empty string `''`, not `'/'`. 
+
 <br>
 
 #### STATS_FILE


### PR DESCRIPTION
Updates the docs to clarify a gotcha with `BUNDLE_DIR_NAME`, as reported by #100.

I don't know what changed between django `1.8` to `2.2` but it took me a good while to figure out that the `/` was the issue now on django `2.2`.