### PR TITLE
Add support for optimized and split chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,23 @@ INSTALLED_APPS = (
 <br>
 
 
+### Webpack Optimized Chunks
+
+Support for default webpack chunk optimizations is supported. The most basic way to enable optimized chunks is to add the
+`optimize` section to your webpack config.
+
+```js
+{
+  ...below plugins
+  
+  optimization: {
+    splitChunks: {
+      chunks: 'all'
+    }
+  }
+}
+```
+
 ### Multiple webpack projects
 
 Version 2.0 and up of webpack loader also supports multiple webpack configurations. The following configuration defines 2 webpack stats files in settings and uses the `config` argument in the template tags to influence which stats file to load the bundles from.

--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -78,7 +78,10 @@ class WebpackLoader(object):
                 )
 
         if assets.get('status') == 'done':
-            chunks = assets['chunks'].get(bundle_name, None)
+            chunks = []
+            for chunk_name, chunk_infos in assets['chunks'].items():
+                if bundle_name in chunk_name.split('~'):
+                    chunks.extend(chunk_infos)
             if chunks is None:
                 raise WebpackBundleLookupError('Cannot resolve bundle {0}.'.format(bundle_name))
             return self.filter_chunks(chunks)


### PR DESCRIPTION
This will write all bundles that contain the bundle_name. This adds support for when splitChunks is enabled, it emits many files. For example here are the chunks from two entry points, settings_rate_cards and settings_regions:
```
settings_rate_cards
settings_rate_cards~settings_regions
settings_regions
vendors~settings_rate_cards
vendors~settings_rate_cards~settings_regions
vendors~settings_regions
```
So if I visit the page the calls `render_bundle('settings_rate_cards')` it will add the following bundles to the page as scripts because they all contain the string "settings_rate_cards":
```
settings_rate_cards
settings_rate_cards~settings_regions
vendors~settings_rate_cards
vendors~settings_rate_cards~settings_regions
```