### PR TITLE
Add Django 2.2 and Python 3.8 to CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,15 @@ workflows:
       - test-3.6-19
       - test-3.6-110
       - test-3.6-111
+      - test-3.6-22
 
       - test-3.7-18
       - test-3.7-19
       - test-3.7-110
       - test-3.7-111
+      - test-3.7-22
+
+      - test-3.8-22
 jobs:
   base: &test-template
     docker:
@@ -141,6 +145,12 @@ jobs:
       - image: circleci/python:3.6-stretch-node
     environment:
       DJANGO_VERSION: "111"
+  test-3.6-22:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.6-stretch-node
+    environment:
+      DJANGO_VERSION: "22"
 
   test-3.7-18:
     <<: *test-template
@@ -166,3 +176,16 @@ jobs:
       - image: circleci/python:3.7-stretch-node
     environment:
       DJANGO_VERSION: "111"
+  test-3.7-22:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.7-stretch-node
+    environment:
+      DJANGO_VERSION: "22"
+
+  test-3.8-22:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.8-buster-node
+    environment:
+      DJANGO_VERSION: "22"

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -42,7 +42,7 @@ INSTALLED_APPS = (
     'django_jinja',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -51,7 +51,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-)
+]
 
 ROOT_URLCONF = 'app.urls'
 

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -13,7 +13,7 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.contrib import admin
 from django.views.generic import TemplateView
 
@@ -21,5 +21,5 @@ from django.views.generic import TemplateView
 
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='home.html'), name='home'),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/tests/requirements/django22.txt
+++ b/tests/requirements/django22.txt
@@ -1,0 +1,2 @@
+django>=2.2,<3
+django_jinja>=2.5


### PR DESCRIPTION
Hi there! I'm crossing my fingers that this works, to support an upgrade that I'm currently doing. These seemed more expedient (and useful) than running the tests locally. That said, I've never used CircleCI, so it's possible it will break due to an error on my part.

The Django 2.2 jobs also use a more recent version of django-jinja for better compatibility ([changelog](https://github.com/niwinz/django-jinja/blob/master/CHANGES.adoc))