### PR TITLE
add alternative package to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,6 @@ Enjoy your webpack with django :)
 
 # Alternatives to Django-Webpack-Loader
 
-_This package is no longer actively maintained. Below are known projects
-that attempt to solve the same problem:_
+_Below are known projects that attempt to solve the same problem:_
 
 * [Django Manifest Loader](https://github.com/shonin/django-manifest-loader)

--- a/README.md
+++ b/README.md
@@ -413,3 +413,10 @@ Then in your base jinja template:
 
 
 Enjoy your webpack with django :)
+
+# Alternatives to Django-Webpack-Loader
+
+_This package is no longer actively maintained. Below are known projects
+that attempt to solve the same problem:_
+
+* [Django Manifest Loader](https://github.com/shonin/django-manifest-loader)


### PR DESCRIPTION
Adds a link in the README to [Django Manifest Loader](https://github.com/shonin/django-manifest-loader), an actively maintained project that solves the same problem. 